### PR TITLE
Refactor layout to showcase new characters

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 import dynamic from 'next/dynamic'
 import { Suspense } from 'react'
-import { CharacterCard } from "@/components/character-card"
 const ImageGallery = dynamic(
   () => import('@/components/image-gallery').then(mod => mod.ImageGallery),
   { ssr: false, loading: () => <div className="h-60 bg-gray-200 animate-pulse rounded-md mb-4" /> }
@@ -13,7 +12,6 @@ const PhotoGallery = dynamic(
   () => import('@/components/photo-gallery').then(mod => mod.PhotoGallery),
   { ssr: false, loading: () => <div className="h-60 bg-gray-200 animate-pulse rounded-md mb-4" /> }
 )
-import { ScrollIndicator } from "@/components/scroll-indicator"
 import { ScrollHandler } from "@/components/scroll-handler"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { BackToTopButton } from "@/components/back-to-top-button"
@@ -28,27 +26,12 @@ export default function Home() {
           <LanguageSwitcher />
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-x-12 gap-y-8 items-start">
-          {/* Row 1, Col 1 */}
-          <div className="lg:col-span-1">
-            <Suspense fallback={<div className="h-80 bg-gray-200 animate-pulse rounded-md mb-4" />}>
-              <CharacterCard />
-            </Suspense>
-          </div>
-          {/* Row 1, Col 2–3 */}
-          <div className="lg:col-span-2">
-            <Suspense>
-              <ImageGallery />
-            </Suspense>
-          </div>
-          {/* Row 2, Col 1 */}
-          <div className="lg:col-span-1" />
-          {/* Row 2, Col 2–3 */}
-          <div className="lg:col-span-2">
-            <div className="mb-16">
-              <AuthorInfo />
-            </div>
-          </div>
+        <Suspense>
+          <ImageGallery />
+        </Suspense>
+
+        <div className="mb-16">
+          <AuthorInfo />
         </div>
       </div>
 

--- a/components/image-gallery.tsx
+++ b/components/image-gallery.tsx
@@ -1,99 +1,41 @@
 "use client"
 
-import { useState } from "react"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Card, CardContent } from "@/components/ui/card"
-import { useTranslation } from "@/lib/i18n/use-translation"
 import Image from "next/image"
-import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface Character {
+  name: string
+  image: string
+  description: string
+}
+
+const CHARACTERS: Character[] = [
+  {
+    name: "新角色A",
+    image: "https://picsum.photos/seed/charA/600/800",
+    description: "这是一段关于角色A的简介。",
+  },
+  {
+    name: "新角色B",
+    image: "https://picsum.photos/seed/charB/600/800",
+    description: "这里是角色B的相关介绍。",
+  },
+]
 
 export function ImageGallery() {
-  const { t } = useTranslation()
-  const [activeTab, setActiveTab] = useState("casual")
-  const [casualVariant, setCasualVariant] = useState<"with" | "without">("with")
-  const CASUAL_WITHOUT_CLOAK = "https://cdn.sa.net/2025/05/18/EGu6CRHASBrwoLl.png?height=500&width=800"
-  const CASUAL_WITH_CLOAK = "https://cdn.sa.net/2025/05/18/y4EfhVPa6sqxtm9.png?height=500&width=800"
-
   return (
-    <Card className="shadow-md">
-      <CardContent className="p-6">
-        <Tabs defaultValue="casual" value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="casual">{t("gallery.casual")}</TabsTrigger>
-            <TabsTrigger value="winter">{t("gallery.winter")}</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="casual" className="mt-4">
-            <div className="flex gap-2 mb-4">
-              <button
-                onClick={() => setCasualVariant("with")}
-                className={`px-4 py-2 rounded ${casualVariant === "with" ? "bg-blue-500 text-white" : "bg-gray-200"}`}
-              >
-                {t("gallery.withCloak")}
-              </button>
-              <button
-                onClick={() => setCasualVariant("without")}
-                className={`px-4 py-2 rounded ${casualVariant === "without" ? "bg-blue-500 text-white" : "bg-gray-200"}`}
-              >
-                {t("gallery.withoutCloak")}
-              </button>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {CHARACTERS.map((c) => (
+        <Card key={c.name} className="shadow-md">
+          <CardContent className="p-4 space-y-4">
+            <div className="relative w-full h-[400px]">
+              <Image src={c.image} alt={c.name} fill className="object-cover rounded-md" />
             </div>
-            <Dialog>
-              <DialogTrigger asChild>
-                <div className="relative w-full rounded-md overflow-hidden bg-white" style={{ paddingTop: "62.5%" }}>
-                  <Image
-                    src={casualVariant === "with" ? CASUAL_WITH_CLOAK : CASUAL_WITHOUT_CLOAK}
-                    alt={t("gallery.casualAlt")}
-                    fill
-                    className="object-contain cursor-zoom-in"
-                  />
-                  <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">
-                    <h3 className="text-white text-xl font-bold">{t("gallery.casualTitle")}</h3>
-                    <p className="text-white/80">{t("gallery.casualDescription")}</p>
-                  </div>
-                </div>
-              </DialogTrigger>
-              <DialogContent className="bg-white p-4 flex justify-center items-center">
-                <Image
-                  src={casualVariant === "with" ? CASUAL_WITH_CLOAK : CASUAL_WITHOUT_CLOAK}
-                  alt={t("gallery.casualAlt")}
-                  width={800}
-                  height={600}
-                  className="object-contain max-w-full max-h-[90vh]"
-                />
-              </DialogContent>
-            </Dialog>
-          </TabsContent>
-
-          <TabsContent value="winter" className="mt-4">
-            <Dialog>
-              <DialogTrigger asChild>
-                <div className="relative w-full h-[400px] md:h-[500px] rounded-md overflow-hidden bg-white cursor-zoom-in">
-                  <Image
-                    src="https://cdn.sa.net/2024/10/23/Rt6CAwJgHL19hiu.png?height=500&width=800"
-                    alt={t("gallery.winterAlt")}
-                    fill
-                    className="object-cover"
-                  />
-                  <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">
-                    <h3 className="text-white text-xl font-bold">{t("gallery.winterTitle")}</h3>
-                    <p className="text-white/80">{t("gallery.winterDescription")}</p>
-                  </div>
-                </div>
-              </DialogTrigger>
-              <DialogContent className="bg-white p-4 flex justify-center items-center">
-                <Image
-                  src="https://cdn.sa.net/2024/10/23/Rt6CAwJgHL19hiu.png?height=500&width=800"
-                  alt={t("gallery.winterAlt")}
-                  width={800}
-                  height={600}
-                  className="object-contain max-w-full max-h-[90vh]"
-                />
-              </DialogContent>
-            </Dialog>
-          </TabsContent>
-        </Tabs>
-      </CardContent>
-    </Card>
+            <h3 className="text-lg font-semibold text-center">{c.name}</h3>
+            <p className="text-sm text-center">{c.description}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove old character card from home page
- redesign home layout to show new characters in a simple gallery
- replace the outfit image gallery with a new two-character showcase

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68405a49500c8325a29f4ab4c19fa1a2