### PR TITLE
Disable sticky scroll on mobile

### DIFF
--- a/components/scroll-handler.tsx
+++ b/components/scroll-handler.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import { useEffect, useRef } from "react"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 export function ScrollHandler() {
+  const isMobile = useIsMobile()
   // 用于记录是否是通过按钮触发的滚动
   const isButtonScrollRef = useRef(false)
   // 用于记录上一次的滚动位置
@@ -11,6 +13,8 @@ export function ScrollHandler() {
   const hasEnteredGalleryRef = useRef(false)
 
   useEffect(() => {
+    if (isMobile) return
+
     const handleScroll = () => {
       const currentScrollY = window.scrollY
       const windowHeight = window.innerHeight
@@ -36,7 +40,7 @@ export function ScrollHandler() {
 
     window.addEventListener("scroll", handleScroll)
     return () => window.removeEventListener("scroll", handleScroll)
-  }, [])
+  }, [isMobile])
 
   // 提供一个方法供其他组件调用，标记滚动是由按钮触发的
   useEffect(() => {

--- a/components/scroll-indicator.tsx
+++ b/components/scroll-indicator.tsx
@@ -2,12 +2,16 @@
 
 import { ChevronDown } from "lucide-react"
 import { useEffect, useState } from "react"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 
 export function ScrollIndicator() {
   const [visible, setVisible] = useState(true)
+  const isMobile = useIsMobile()
 
   useEffect(() => {
+    if (isMobile) return
+
     const handleScroll = () => {
       // 一旦滚动就隐藏指示器
       setVisible(false)
@@ -27,7 +31,7 @@ export function ScrollIndicator() {
 
     window.addEventListener("scroll", handleScroll)
     return () => window.removeEventListener("scroll", handleScroll)
-  }, [])
+  }, [isMobile])
 
   const scrollToGallery = () => {
     const windowHeight = window.innerHeight


### PR DESCRIPTION
## Summary
- disable automatic scroll snapping on mobile devices
- skip scroll indicator auto-scroll on mobile

## Testing
- `pnpm test`
- `pnpm lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_6840e7011b68832581f832dffa669899